### PR TITLE
Fixed most immediate crashes for automatic harvesting

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -30,21 +30,22 @@ end
 end ]]
 
 function On_Load()
-	for _, harvester in pairs(global.cncharvesters) do
-		-- Allow it to re-set its metatable.
-		cncharvester.Onload(harvester)
-	end
 	for _, refinery in pairs(global.refineries) do
 		-- Allow it to re-set its metatable.
 		Refinery.Onload(refinery)
 	end
+	for _, harvester in pairs(global.cncharvesters) do
+		-- Allow it to re-set its metatable.
+		cncharvester.Onload(harvester)
+	end
 end
+script.on_load(On_Load)
 
 function On_Built(event)
 	local ent = event.created_entity or event.entity
 	if not (ent and ent.valid) then return end
 	if ent.name == "cncharvester" or ent.name == "cncharvester-type2" then
-		table.insert(global.cncharvesters, cncharvester.New(ent))
+		global.cncharvesters[ent.unit_number] = cncharvester.New(ent)
 	elseif ent.name == "refinery" then
 		global.refineries[ent.unit_number] = Refinery.New(ent)
 	end
@@ -161,11 +162,12 @@ end
 
 script.on_nth_tick(60, On_Tick_Driving_Players)
 
-if autocncharvestertesting and global.cncharvesters then
+if autocncharvestertesting then
 	script.on_nth_tick(1, function() 
-		for _, harvester in pairs(global.cncharvesters) do
-			-- game.print(_ .. ': ' .. serpent.block(harvester))
-			harvester:Tick()
+		if global.cncharvesters then
+			for _, harvester in pairs(global.cncharvesters) do
+				harvester:Tick()
+			end
 		end
 	end)
 end

--- a/control.lua
+++ b/control.lua
@@ -30,9 +30,9 @@ end
 end ]]
 
 function On_Load()
-	for _, cncharvester in pairs(global.cncharvesters) do
+	for _, harvester in pairs(global.cncharvesters) do
 		-- Allow it to re-set its metatable.
-		cncharvester.Onload(cncharvester)
+		cncharvester.Onload(harvester)
 	end
 	for _, refinery in pairs(global.refineries) do
 		-- Allow it to re-set its metatable.
@@ -161,7 +161,7 @@ end
 
 script.on_nth_tick(60, On_Tick_Driving_Players)
 
-if autocncharvestertesting then
+if autocncharvestertesting and global.cncharvesters then
 	script.on_nth_tick(1, function() 
 		for _, harvester in pairs(global.cncharvesters) do
 			-- game.print(_ .. ': ' .. serpent.block(harvester))

--- a/harvester.lua
+++ b/harvester.lua
@@ -507,7 +507,7 @@ cncharvester = {
 			-- If the refinery is still there and we can dump the complete contents of our cargo hold.
 			local targetRefinery = Refinery.GetByUnitNumber(self.targetRefinery)
 			if targetRefinery.entity.valid then
-				if targetRefinery.GetAvailableSlots() > Stats.cncharvesterCargoSlots then
+				if targetRefinery:GetAvailableSlots() > Stats.cncharvesterCargoSlots then
 					for itemname, count in pairs(inv.get_contents()) do
 						local stack = {name = itemname, count = count}
 						-- Dump our inventory into the refinery.

--- a/refinery.lua
+++ b/refinery.lua
@@ -36,6 +36,10 @@ Refinery = {
 	--										   Static functions											--
 	--------------------------------------------------++--------------------------------------------------
 	-- Static functions.
+	GetByUnitNumber = function(unitNumber) 
+		return global.refineries[unitNumber]
+	end,
+
 	NearestUnoccupied = function(position)
 		return Refinery.NearestWithCondition(
 			position, 

--- a/specialOres.lua
+++ b/specialOres.lua
@@ -1,0 +1,3 @@
+SpecialOres = {
+    ["harvester-example-ore"] = function() return "raw-harvester-example-ore" end,
+}

--- a/specialOres.lua
+++ b/specialOres.lua
@@ -1,3 +1,4 @@
+-- Map special ores, such as silica where the resource is called "silica" and the item is called "raw-silica".
 SpecialOres = {
     ["harvester-example-ore"] = function() return "raw-harvester-example-ore" end,
 }

--- a/utilities.lua
+++ b/utilities.lua
@@ -56,7 +56,10 @@ function DeltaposToOrientation(dPos)
 end
 
 function GetBoundingBox(position, radius)
-	return {{position.x - radius, position.y - radius}, {position.x + radius, position.y + radius}}
+	return {
+		{position.x - radius, position.y - radius},
+		{position.x + radius, position.y + radius}
+	}
 end
 
 function FindNearestEntity(baseEntity, entList)


### PR DESCRIPTION
- Feature flag "Auto-cncharvester-testing" is now functional
- Automatic harvesting, returning and refuelling works without immediate crashes

To achieve that I had to:

- Comment out Animation-related code in Harvester class, as some resources seem to be missing in the repository (`Animations`, `cncharvesterAnimator`, animation prototype `cncharvester-anim`)
- Remove the no longer needed hidden chest of the refinery, fix several inventory related things
- Add "SpecialOres" table for the Harvester-logic to handle, well, special ores.
- Replaced `getBoundingBox` with `GetBoundingBox` from Utilities file

The overall experience of the automatic harvesting is still far from perfect, but it's a good step to build on :)

Remaining essential issues:
- ✅ Loading a game that was started with active feature flag leads to another crash